### PR TITLE
Performance and memory enhancement for transitionCount

### DIFF
--- a/policy.cpp
+++ b/policy.cpp
@@ -12,14 +12,11 @@ Policy::Policy(int states, int actions)
 {
   this->states = states;
   this->actions = actions;
-  transitionCount = new int**[states];
+  transitionCount = new basearray<int,2> *[states];
   for(int i = 0; i < states; i++)
-    {
-      transitionCount[i] = new int*[actions];
-      for(int j=0;j<actions;j++)
-	transitionCount[i][j] = new int[2]{0,0};
-    }
-  std::cout << "Policy initialized with "<<states<<" states and "<<actions<<" actions.\n";
+    transitionCount[i] = new basearray<int,2>[actions];
+  // std::cout << "Policy initialized with " << states << " states and " <<
+  //   actions << " actions.\n";
 }
 
 
@@ -28,11 +25,7 @@ Policy::~Policy()
   if(transitionCount != NULL)
     {
       for(int i = 0; i < states; i++)
-	{
-	  for(int j=0;j<actions;j++)
-	    delete[] transitionCount[i][j];
-	  delete[] transitionCount[i];
-	}      
+        delete[] transitionCount[i];
       delete[] transitionCount;
     }
 }

--- a/policy.h
+++ b/policy.h
@@ -15,12 +15,28 @@ struct StateTransition
 	State sPrime;
 };
 
+/*
+  Sometimes we need to dynamically allocate a 2-D array with small
+  width.  The standard way to allocate 2-d array is an array of
+  pointers, one for each row, then an array of elements for each row.
+  But creating a type for the colums is more efficient in space and
+  time if there are only a few columns, and the number of columns is
+  static.
+*/
+template <typename T,int size> struct basearray{
+  T items[size];  // array of items
+  T& operator [](int idx)  // overload subscription operator
+  {
+    return items[idx];
+  }
+};
+
 class Policy {
   int states,actions;
 	private:
 		// State states[NumStates][actions][LinkedListUpToNumStates, totNum];
-  		// int transitionCount[16][ACTION_SIZE][2];
-  int ***transitionCount;  // [# of states][ACTION_SIZE][2];
+  // int transitionCount[16][ACTION_SIZE][2];
+  basearray<int,2> **transitionCount;  // [# of states][ACTION_SIZE][2];
 
 
 		//vector<State> **states; //contains model of states. Expandable


### PR DESCRIPTION
This should reduce memory used to store transitionCount by almost 50%, and increase performance by about 25%.